### PR TITLE
Feat: 카카오 회원 가입(로그인) 기능 추가

### DIFF
--- a/commerce03/src/main/java/com/supercoding/commerce03/repository/user/entity/UserDetail.java
+++ b/commerce03/src/main/java/com/supercoding/commerce03/repository/user/entity/UserDetail.java
@@ -34,19 +34,19 @@ public class UserDetail {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	@Column(name = "password", nullable = false)
+	@Column(name = "password")
 	private String password;
 
-	@Column(name = "address", nullable = false)
+	@Column(name = "address")
 	private String address;
 
-	@Column(name = "phone_number", nullable = false)
+	@Column(name = "phone_number")
 	private String phoneNumber;
 
 	@Column(name = "email", nullable = false)
 	private String email;
 
-	@Column(name = "detail_address", nullable = false)
+	@Column(name = "detail_address")
 	private String detailAddress;
 
 	public static UserDetail toEntity(User user, SignUp signUp, String passwordEncode) {

--- a/commerce03/src/main/java/com/supercoding/commerce03/service/user/KaKaoLoginService.java
+++ b/commerce03/src/main/java/com/supercoding/commerce03/service/user/KaKaoLoginService.java
@@ -1,0 +1,69 @@
+package com.supercoding.commerce03.service.user;
+
+import com.supercoding.commerce03.repository.user.UserDetailRepository;
+import com.supercoding.commerce03.repository.user.UserRepository;
+import com.supercoding.commerce03.repository.user.entity.User;
+import com.supercoding.commerce03.repository.user.entity.UserDetail;
+import com.supercoding.commerce03.service.security.JwtTokenProvider;
+import com.supercoding.commerce03.service.user.exception.UserErrorCode;
+import com.supercoding.commerce03.service.user.exception.UserException;
+import com.supercoding.commerce03.web.dto.user.KakaoLogin;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KaKaoLoginService {
+
+    private final UserRepository userRepository;
+
+    private final UserDetailRepository userDetailRepository;
+
+    public ResponseEntity<String> emailExists(KakaoLogin kakaoLogin) {
+        //이메일과 회원 이름 이 들어온다 (이메일을 갖고올 때 isDelete t인지 f인지)
+        Optional<UserDetail> optionalUserDetail = userDetailRepository.findByEmail(kakaoLogin.getEmail());
+
+        //만약 이메일이 현재 존재하지 않는 경우에는
+        if (optionalUserDetail.isEmpty()){
+            User user = userRepository.save(User.builder()
+                    .createdAt(LocalDateTime.now())
+                    .userName(kakaoLogin.getUserName())
+                    .isDeleted(false)
+                .build());
+
+            UserDetail userDetail = userDetailRepository.save(UserDetail.builder()
+                .email(kakaoLogin.getEmail())
+                .build());
+            //토큰 생성
+           String token = makeLoginResponse(user,userDetail);
+            //해당 메세지를 보낸다
+            HttpHeaders header = new HttpHeaders();
+            header.set("Authorization", "Bearer " + token);
+
+            return  new ResponseEntity<>("신규회원 입니다 회원 수정으로 이동해주세요",header,HttpStatus.ACCEPTED);
+        }
+        else {
+            //토큰을 생성한다
+            String token = makeLoginResponse(optionalUserDetail.get().getUser(), optionalUserDetail.get());
+
+            //해당 메세지를 보낸다
+            HttpHeaders header = new HttpHeaders();
+            header.set("Authorization", "Bearer " + token);
+
+            return new ResponseEntity<>("기존 회원입니다 로그인 완료!",header,HttpStatus.OK);
+
+        }
+    }
+
+
+    public String makeLoginResponse(User user, UserDetail userDetail) {
+        return JwtTokenProvider.createToken(user, userDetail);
+    }
+}

--- a/commerce03/src/main/java/com/supercoding/commerce03/service/user/exception/UserErrorCode.java
+++ b/commerce03/src/main/java/com/supercoding/commerce03/service/user/exception/UserErrorCode.java
@@ -17,12 +17,8 @@ public enum UserErrorCode {
     INVALID_PASSWORD("올바르지 않은 비밀번호 양식 입니다.",HttpStatus.BAD_REQUEST),
     INVALID_LOGIN_INPUT("해당 회원은 없습니다 다시 한번 입력 해줏세요 ",HttpStatus.BAD_REQUEST),
     //status(HttpStatus.NOT_FOUND) 404
-    USER_NOT_FOUND("존재하지 않는 유저 입니다.", HttpStatus.NOT_FOUND),
+    USER_NOT_FOUND("존재하지 않는 유저 입니다.", HttpStatus.NOT_FOUND);
 
-    //status(HttpStatus.Accepted) 202
-    IS_NEW_USER("신규 유저 입니다.", HttpStatus.ACCEPTED),
-    //status(HttpStatus.OK) 200
-    IS_EXIST_USER("기존 유저 입니다.", HttpStatus.OK);
     private final String description;
     private final HttpStatus httpStatus;
 }

--- a/commerce03/src/main/java/com/supercoding/commerce03/web/controller/user/KakaoLoginController.java
+++ b/commerce03/src/main/java/com/supercoding/commerce03/web/controller/user/KakaoLoginController.java
@@ -1,0 +1,24 @@
+package com.supercoding.commerce03.web.controller.user;
+
+import com.supercoding.commerce03.service.user.KaKaoLoginService;
+import com.supercoding.commerce03.web.dto.user.KakaoLogin;
+import com.supercoding.commerce03.web.dto.user.SignUp;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/api/kakao")
+public class KakaoLoginController {
+    private final KaKaoLoginService kaKaoLoginService;
+    @PostMapping
+    public ResponseEntity<String> kakaoLogin(@RequestBody KakaoLogin kakaoLogin) {
+
+    return kaKaoLoginService.emailExists(kakaoLogin);
+    }
+}

--- a/commerce03/src/main/java/com/supercoding/commerce03/web/dto/user/KakaoLogin.java
+++ b/commerce03/src/main/java/com/supercoding/commerce03/web/dto/user/KakaoLogin.java
@@ -1,0 +1,18 @@
+package com.supercoding.commerce03.web.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class KakaoLogin {
+
+    private String userName;
+    private String email;
+}


### PR DESCRIPTION
카카오 로그인이 완료된 후 서버에 회원 이름과 이메일이 들어오게 되는데 이를 이메일을 통해 기존회원인지 신규회원인지 검사를 하고 신규 회원의 경우는 들어오는 회원 이름과 이메일을 저장해주고 토큰을 보내주며 기존회원의 경우는 로그인을 하는 로직으로 토큰을 보내줍니다